### PR TITLE
yield a logger to SemanticLogger.tagged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Yield the logger instance to `SemanticLogger.tagged` for compatibility with ActiveSupport::TaggedLogging
+
 ## [4.10.0]
 
 - New Feature: Add support for newer `sentry-ruby` gem.

--- a/lib/semantic_logger/semantic_logger.rb
+++ b/lib/semantic_logger/semantic_logger.rb
@@ -10,6 +10,22 @@ module SemanticLogger
     Logger.new(klass)
   end
 
+  def self.default_logger
+    @default_logger ||= Logger.new(self)
+  end
+
+  def self.current_logger
+    Thread.current[:semantic_logger_current_logger] || default_logger
+  end
+
+  def self.with_current_logger(logger)
+    prev_logger = current_logger
+    Thread.current[:semantic_logger_current_logger] = logger
+    yield
+  ensure
+    Thread.current[:semantic_logger_current_logger] = prev_logger
+  end
+
   # Sets the global default log level
   def self.default_level=(level)
     @default_level = level
@@ -311,12 +327,12 @@ module SemanticLogger
   # If the tag being supplied is definitely a string then this fast
   # tag api can be used for short lived tags
   def self.fast_tag(tag)
-    return yield if tag.nil? || tag == ""
+    return yield(current_logger) if tag.nil? || tag == ""
 
     t = Thread.current[:semantic_logger_tags] ||= []
     begin
       t << tag
-      yield
+      yield(current_logger)
     ensure
       t.pop
     end
@@ -343,7 +359,7 @@ module SemanticLogger
   #   to the equivalent of:
   #     `logger.tagged('first', 'more', 'other')`
   def self.tagged(*tags, &block)
-    return yield if tags.empty?
+    return yield(current_logger) if tags.empty?
 
     # Allow named tags to be passed into the logger
     if tags.size == 1
@@ -353,7 +369,7 @@ module SemanticLogger
 
     begin
       push_tags(*tags)
-      yield
+      yield(current_logger)
     ensure
       pop_tags(tags.size)
     end
@@ -387,12 +403,12 @@ module SemanticLogger
 
   # :nodoc
   def self.named_tagged(hash)
-    return yield if hash.nil? || hash.empty?
+    return yield(current_logger) if hash.nil? || hash.empty?
     raise(ArgumentError, "#named_tagged only accepts named parameters (Hash)") unless hash.is_a?(Hash)
 
     begin
       push_named_tags(hash)
-      yield
+      yield(current_logger)
     ensure
       pop_named_tags
     end

--- a/test/semantic_logger_test.rb
+++ b/test/semantic_logger_test.rb
@@ -33,6 +33,15 @@ class SemanticLoggerTest < Minitest::Test
           end
         end
 
+        it "add tags to log entries taking a block argument" do
+          SemanticLogger.tagged("12345", "DJHSFK") do |l|
+            l.info("Hello world")
+
+            assert log = log_message
+            assert_equal %w[12345 DJHSFK], log.tags
+          end
+        end
+
         it "add embedded tags to log entries" do
           SemanticLogger.tagged("First Level", "tags") do
             SemanticLogger.tagged("Second Level") do


### PR DESCRIPTION
# DO NOT MERGE

See: https://github.com/reidmorrison/semantic_logger/pull/208

This branch is used in doximity's production apps until we can get the open source change merged.