### PR TITLE
Update to self hosted GHA runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: "Test: Ruby ${{ matrix.ruby }}"
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
     services:
       mongodb:
         image: mongo


### PR DESCRIPTION
Updating from the GHA cloud runner instance to our own self hosted runners, the cost of cloud runners is ~4x what we spend to self host.

[_Created by Sourcegraph batch change `NoHesHere/update-to-general-purpose`._](https://sourcegraph.build.dox.pub/users/NoHesHere/batch-changes/update-to-general-purpose)